### PR TITLE
[Bug] Fix curl post opts error.

### DIFF
--- a/src/Widop/GoogleAnalytics/Client.php
+++ b/src/Widop/GoogleAnalytics/Client.php
@@ -177,7 +177,7 @@ class Client
                 'assertion'      => $this->generateJsonWebToken(),
             );
 
-            $response = json_decode($this->httpAdapter->postContent($this->url, $headers, $content));
+            $response = json_decode($this->httpAdapter->postContent($this->url, $headers, http_build_query($content)));
 
             if (isset($response->error)) {
                 throw GoogleAnalyticsException::invalidAccessToken($response->error);


### PR DESCRIPTION
Passing an array to CURLOPT_POSTFIELDS will encode the data as multipart/form-data, while passing a URL-encoded string will encode the data as application/x-www-form-urlencoded.

source: http://php.net/manual/en/function.curl-setopt.php
